### PR TITLE
Add status code support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    get_schwifty (0.1.1)
+    get_schwifty (0.2.0)
       rails (> 5)
 
 GEM
@@ -60,7 +60,7 @@ GEM
       ffi (~> 1.0, >= 1.0.11)
     concurrent-ruby (1.0.5)
     crass (1.0.2)
-    erubi (1.6.1)
+    erubi (1.7.0)
     ffi (1.9.18)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
@@ -116,11 +116,11 @@ GEM
       rake
     rake (12.1.0)
     redis (3.3.3)
-    rubocop (0.50.0)
+    rubocop (0.49.0)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
-      rainbow (>= 2.2.2, < 3.0)
+      rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
@@ -155,7 +155,7 @@ DEPENDENCIES
   get_schwifty!
   puma
   redis
-  rubocop (~> 0.49)
+  rubocop (= 0.49)
   selenium-webdriver
   sqlite3
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ class CalculatorCable < BaseCable
 end
 ```
 
-When the data has been queried/generated, the partial is rendered. `stream` is a wrapper around the normal Rails `render`.
+When the data has been queried/generated, the partial is rendered. `stream` is a wrapper around the normal Rails `render`. Want to redirect to another location? use the pass the path or URL to the `redirect` method.
 
 ```erb
 # app/views/cables/calculator/_fibonacci.html.erb

--- a/get_schwifty.gemspec
+++ b/get_schwifty.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "redis"
-  s.add_development_dependency "rubocop", "~> 0.49"
+  s.add_development_dependency "rubocop", "0.49"
 end

--- a/lib/generators/templates/cables/base_cable.rb
+++ b/lib/generators/templates/cables/base_cable.rb
@@ -2,6 +2,7 @@
 
 # Base cable class to inherit from when getting schwifty
 class BaseCable < GetSchwifty::Cable::Base
+  include Rails.application.routes.url_helpers
   # Access to pundit helper methods for authorization
   # include Pundit
 

--- a/lib/get_schwifty/cable/base.rb
+++ b/lib/get_schwifty/cable/base.rb
@@ -17,7 +17,16 @@ module GetSchwifty
       def stream(*args)
         ActionCable.server.broadcast(
           schwifty_job_id,
-          GetSchwiftyController.renderer.new.render(*args).squish
+          status: 200,
+          body: GetSchwiftyController.renderer.new.render(*args).squish
+        )
+      end
+
+      def redirect(url)
+        ActionCable.server.broadcast(
+          schwifty_job_id,
+          status: 302,
+          body: url
         )
       end
     end

--- a/lib/get_schwifty/version.rb
+++ b/lib/get_schwifty/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GetSchwifty
-  VERSION = "0.1.1"
+  VERSION = "0.2.0"
 end

--- a/test/dummy/app/cables/base_cable.rb
+++ b/test/dummy/app/cables/base_cable.rb
@@ -2,6 +2,7 @@
 
 # Base cable class to inherit from when getting schwifty
 class BaseCable < GetSchwifty::Cable::Base
+  include Rails.application.routes.url_helpers
   # Access to pundit helper methods for authorization
   # include Pundit
 

--- a/test/dummy/app/cables/demo_cable.rb
+++ b/test/dummy/app/cables/demo_cable.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class DemoCable < BaseCable
+  def build
+    sleep 5
+
+    redirect demo_path(id: DateTime.current)
+  end
+end

--- a/test/dummy/app/channels/application_cable/connection.rb
+++ b/test/dummy/app/channels/application_cable/connection.rb
@@ -11,13 +11,7 @@ module ApplicationCable
     private
 
     def find_verified_user
-      current_user = User.find_by(id: cookies.signed[:user_id])
-
-      if current_user
-        current_user
-      else
-        reject_unauthorized_connection
-      end
+      User.find_by(id: cookies.signed[:user_id])
     end
   end
 end

--- a/test/dummy/app/controllers/demos_controller.rb
+++ b/test/dummy/app/controllers/demos_controller.rb
@@ -1,0 +1,5 @@
+class DemosController < ApplicationController
+  def index; end
+
+  def show; end
+end

--- a/test/dummy/app/views/demos/index.html.erb
+++ b/test/dummy/app/views/demos/index.html.erb
@@ -1,0 +1,3 @@
+<%= get_schwifty "demo#build" do %>
+  <h1>Inserting demo data...</h1>
+<% end %>

--- a/test/dummy/app/views/demos/show.html.erb
+++ b/test/dummy/app/views/demos/show.html.erb
@@ -1,0 +1,1 @@
+<h1 class="rendered">Demo data was inserted</h1>

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  resources :demos, only: %i[index show]
+
   root "calculators#index"
 end

--- a/test/system_test.rb
+++ b/test/system_test.rb
@@ -22,4 +22,11 @@ class SystemTest < ApplicationSystemTestCase
       assert_selector ".double-x-schwifty-201"
     end
   end
+
+  test "redirection" do
+    visit demos_path
+
+    # find ".rendered", wait: 10
+    assert_selector ".rendered", wait: 10
+  end
 end


### PR DESCRIPTION
+ Follow HTTP status code convention for determining exactly how to react. Default action is to insert the text which is the body.

+ Add support for redirecting to a different location. Possibly useful if you're building demo data, generating a PDF, or some other long running job which generates a different resource.